### PR TITLE
Revert change to char_size dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@
 
 source "https://rubygems.org"
 gemspec
+
+gem "char_size", "~> 0.2.0", platforms: :ruby

--- a/tar.gemspec
+++ b/tar.gemspec
@@ -22,8 +22,6 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^#{spec.bindir}/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "char_size", "~> 0.2.0"
-
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "minitest", "~> 5.13"
   spec.add_development_dependency "pry", "~> 0.12"


### PR DESCRIPTION
`char_size` is a development-only dependency and only supports MRI; it generates `lib/char_size.rb` using `rake char_size`